### PR TITLE
Tag OpenBench git commit in docker biulds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,16 @@ RUN groupadd openbench && \
 USER openbench:openbench
 
 # Download the client from github, clean-up some unneeded files and directories
-# to save some space
+# to save some space.
+#
+# Note: argument OPENBENCH_GIT_HASH must be set
+ARG OPENBENCH_GIT_HASH
 RUN cd /openbench && \
     git lfs install && \
     git clone --single-branch --branch master https://github.com/AndyGrant/OpenBench.git && \
     cd OpenBench && \
+    git config advice.detachedHead false && \
+    git checkout "${OPENBENCH_GIT_HASH}" && \
     rm -r .git CoreFiles/cutechess-windows.exe
 
 # Entrypoint bash scripts
@@ -67,8 +72,9 @@ COPY bin/* /usr/local/bin/
 COPY scripts/* /scripts/
 
 LABEL description="OpenBench Testing Framework client for http://chess.grantnet.us/ . \
-Please see https://hub.docker.com/repository/docker/skiminki/openbench-client\
+Please see https://hub.docker.com/repository/docker/skiminki/openbench-client \
 on how to configure the container. Sources to build the Docker image at \
-https://github.com/skiminki/openbench-client-docker ."
+https://github.com/skiminki/openbench-client-docker . \
+OpenBench Testing Framework client git commit: ${OPENBENCH_GIT_HASH}"
 
 ENTRYPOINT ["/openbench-entrypoint.sh"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+OPENBENCH_GIT_HASH="$(git ls-remote https://github.com/AndyGrant/OpenBench.git HEAD | head -n 1 | awk '{ print $1 }')"
+
+docker build . \
+       -t skiminki/openbench-client:latest \
+       --build-arg "OPENBENCH_GIT_HASH=${OPENBENCH_GIT_HASH}"


### PR DESCRIPTION
Add argument in Dockerfile for git commit for OpenBench git checkout. This tags the exact version of OpenBench that the container has. It also makes rebuilding the container for new OpenBench versions easier.

Add build.sh that resolves the current OpenBench git head and invokes the docker build.