### PR TITLE
Switch to Ubuntu 22.10 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Baseline
-FROM ubuntu:22.04
+FROM ubuntu:22.10
 
 # Update and install packages needed to run OpenBench engine testing
 RUN apt-get update && \


### PR DESCRIPTION
Switch to Ubuntu 22.10 base image for updated compilers and other packages.