### PR TITLE
Remove openbench.exit on launch

### DIFF
--- a/openbench-entrypoint.sh
+++ b/openbench-entrypoint.sh
@@ -63,6 +63,7 @@ case "${CMD}" in
 	    exit 3
 	fi
 	configure_openbench_client
+	rm -f "$WORKER_EXIT_FILE"
 	launch_openbench_client
 	;;
 


### PR DESCRIPTION
A stale /openbench/OpenBench/Client/openbench.exit may be left behind when the client has been signaled to exit and then killed before the client exited by itself. This can lead to the client exiting immediately after the next launch. So, remove this file on launch to prevent the double exit.